### PR TITLE
fixed regexs

### DIFF
--- a/app/views/parties/_new_form.html.erb
+++ b/app/views/parties/_new_form.html.erb
@@ -164,8 +164,8 @@ function getAddressComponents(place) {
   var EVENTS = 'focusout keyup change';
   var EMAIL_PATTERN =/^([^\.@]+)(\.([^@]+))?@([^@]+)\.([^@]+)$/;
   var ZIP_CODE_PATTERN = /^\d{4,5}$/;
-  var MOBILE_PHONE_PATTERN = /^\d{8,12}$/;
-  var NAME_PATTERN = /^([a-z]){2,}$/;
+  var MOBILE_PHONE_PATTERN = /1?\W*([2-9][0-8][0-9])\W*([2-9][0-9]{2})\W*([0-9]{4})(\se?x?t?(\d*))?/;
+  var NAME_PATTERN = /^([a-zA-Z]){2,}$/;
 
 
   function checkIsFilled(input, add_class) {


### PR DESCRIPTION
added more comprehensive regexs. We are using a german address right? finding a regexp that does postal codes well is a pain in the ass. most countries use 5 digits. this one supports 4 and 5 digits.